### PR TITLE
处理荣耀新款手机或者系统无法跳转系统管家页面的兼容性问题

### DIFF
--- a/android/src/main/java/com/reactnative/platform/ManufacturerBackgroundSettings.java
+++ b/android/src/main/java/com/reactnative/platform/ManufacturerBackgroundSettings.java
@@ -40,8 +40,13 @@ public class ManufacturerBackgroundSettings {
     }
 
     private static void openHonorPhoneManagerActivity(Context context) throws Exception {
-        openActivity(context, "com.hihonor.systemmanager",
-            "com.huawei.systemmanager.mainscreen.MainScreenActivity");
+        try {
+            openActivity(context, "com.hihonor.systemmanager",
+                "com.huawei.systemmanager.mainscreen.MainScreenActivity");
+        } catch (Exception e) {
+            openActivity(context, "com.hihonor.systemmanager",
+                "com.hihonor.systemmanager.mainscreen.MainScreenActivity");
+        }
     }
 
     // 跳转小米安全中心的自启动管理页面


### PR DESCRIPTION
如：荣耀(honor) Magic 4，荣耀50系列,60系列，70系列